### PR TITLE
Update winModal.js

### DIFF
--- a/src/components/Modals/winModal.js
+++ b/src/components/Modals/winModal.js
@@ -48,7 +48,7 @@ function WinModal( { showWin, resetGame, answer, clues } ) {
   return (
     <>
       <div style={{position: 'relative', zIndex: 1000}}>
-        <Confetti active={ showWin } config={ confettiConfig }/>
+        <Confetti active={ showWin } config={ {...confettiConfig, colors:answer} }/>
       </div>
       <div style={{position: 'relative', zIndex: 999}}>
         <Modal


### PR DESCRIPTION
- Confetti colors now matches the answer colors.
- Screenshot of confetti and answer colors side by side below
![image](https://github.com/LeviGreen/master-mind/assets/84234570/f01670c6-7a2f-4cbe-bd94-73d4ac21bf0e)
