### PR TITLE
Update winModal.js : confetti colors matches the answer colors

### DIFF
--- a/src/components/Modals/winModal.js
+++ b/src/components/Modals/winModal.js
@@ -48,7 +48,7 @@ function WinModal( { showWin, resetGame, answer, clues } ) {
   return (
     <>
       <div style={{position: 'relative', zIndex: 1000}}>
-        <Confetti active={ showWin } config={ confettiConfig }/>
+        <Confetti active={ showWin } config={ {...confettiConfig, colors:answer} }/>
       </div>
       <div style={{position: 'relative', zIndex: 999}}>
         <Modal


### PR DESCRIPTION
- The confetti colors now matches the answer colors

- Screenshot of the confetti colors and answer colors side by side
![image](https://github.com/LeviGreen/master-mind/assets/84234570/20617490-6840-47d4-a88b-46b7d558789d)
